### PR TITLE
Fixed bug on windows cli binary path

### DIFF
--- a/Assets/GoogleARCore/SDK/Scripts/AugmentedImageDatabase.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/AugmentedImageDatabase.cs
@@ -268,7 +268,8 @@ namespace GoogleARCore
                 return false;
             }
 
-            path = AssetDatabase.GUIDToAssetPath(cliBinaryGuid[0]);
+            string projectPath = Application.dataPath.Substring(0, Application.dataPath.Length - 6);
+            path = @"" + projectPath + AssetDatabase.GUIDToAssetPath(cliBinaryGuid[0]);
             return !string.IsNullOrEmpty(path);
         }
         /// @endcond

--- a/Assets/GoogleARCore/SDK/Scripts/Editor/AugmentedImageDatabasePreprocessBuild.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/Editor/AugmentedImageDatabasePreprocessBuild.cs
@@ -24,6 +24,7 @@ namespace GoogleARCoreInternal
     using GoogleARCore;
     using UnityEditor;
     using UnityEditor.Build;
+    using UnityEditor.Build.Reporting;
 
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented",
      Justification = "Internal")]
@@ -38,6 +39,25 @@ namespace GoogleARCoreInternal
                 return 0;
             }
         }
+
+#if UNITY_2018
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            var augmentedImageDatabaseGuids = AssetDatabase.FindAssets("t:AugmentedImageDatabase");
+            foreach (var databaseGuid in augmentedImageDatabaseGuids)
+            {
+                var database = AssetDatabase.LoadAssetAtPath<AugmentedImageDatabase>(
+                    AssetDatabase.GUIDToAssetPath(databaseGuid));
+
+                string error;
+                database.BuildIfNeeded(out error);
+                if (!string.IsNullOrEmpty(error))
+                {
+                    throw new BuildFailedException(error);
+                }
+            }
+        }
+#endif
 
         public void OnPreprocessBuild(BuildTarget target, string path)
         {
@@ -55,5 +75,6 @@ namespace GoogleARCoreInternal
                 }
             }
         }
+
     }
 }

--- a/Assets/GoogleARCore/SDK/Scripts/Editor/CloudAnchorPreprocessBuild.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/Editor/CloudAnchorPreprocessBuild.cs
@@ -25,6 +25,7 @@ namespace GoogleARCoreInternal
     using System.Text;
     using UnityEditor;
     using UnityEditor.Build;
+    using UnityEditor.Build.Reporting;
     using UnityEngine;
 
     internal class CloudAnchorPreprocessBuild : IPreprocessBuild
@@ -42,6 +43,20 @@ namespace GoogleARCoreInternal
                 return 0;
             }
         }
+
+#if UNITY_2018
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            if (report.summary.platform == BuildTarget.Android)
+            {
+                _PreprocessAndroidBuild();
+            }
+            else if (report.summary.platform == BuildTarget.iOS)
+            {
+                _PreprocessIosBuild();
+            }
+        }
+#endif
 
         public void OnPreprocessBuild(BuildTarget target, string path)
         {

--- a/Assets/GoogleARCore/SDK/Scripts/Editor/RequiredOptionalPreprocessBuild.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/Editor/RequiredOptionalPreprocessBuild.cs
@@ -24,6 +24,7 @@ namespace GoogleARCoreInternal
     using System.IO;
     using UnityEditor;
     using UnityEditor.Build;
+    using UnityEditor.Build.Reporting;
     using UnityEngine;
 
     internal class RequiredOptionalPreprocessBuild : IPreprocessBuild
@@ -38,6 +39,21 @@ namespace GoogleARCoreInternal
             }
         }
 
+#if UNITY_2018
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            var isARCoreRequired = ARCoreProjectSettings.Instance.IsARCoreRequired;
+
+            Debug.LogFormat("Building application with {0} ARCore support.",
+                isARCoreRequired ? "REQUIRED" : "OPTIONAL");
+
+            AssetHelper.GetPluginImporterByName("google_ar_required.aar")
+                .SetCompatibleWithPlatform(BuildTarget.Android, isARCoreRequired);
+            AssetHelper.GetPluginImporterByName("google_ar_optional.aar")
+                .SetCompatibleWithPlatform(BuildTarget.Android, !isARCoreRequired);
+        }
+#endif
+
         public void OnPreprocessBuild(BuildTarget target, string path)
         {
             var isARCoreRequired = ARCoreProjectSettings.Instance.IsARCoreRequired;
@@ -50,5 +66,6 @@ namespace GoogleARCoreInternal
             AssetHelper.GetPluginImporterByName("google_ar_optional.aar")
                 .SetCompatibleWithPlatform(BuildTarget.Android, !isARCoreRequired);
         }
+
     }
 }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.3.0f2
+m_EditorVersion: 2018.1.0f2


### PR DESCRIPTION
Seems that NET4.0 expects a process binary path to be absolute if it is not in System32 directory. I've written a fix which finds the current project directory and appends to the begins of the binary path.