### PR TITLE
Camera projection matrix to camera FOV conversion

### DIFF
--- a/Assets/GoogleARCore/SDK/Scripts/ARCoreBackgroundRenderer.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/ARCoreBackgroundRenderer.cs
@@ -92,8 +92,11 @@ namespace GoogleARCore
             BackgroundMaterial.SetVector(bottomLeftRightVar,
                 new Vector4(uvQuad.BottomLeft.x, uvQuad.BottomLeft.y, uvQuad.BottomRight.x, uvQuad.BottomRight.y));
 
-            m_Camera.projectionMatrix = Frame.CameraImage.GetCameraProjectionMatrix(
+            var prjMat = Frame.CameraImage.GetCameraProjectionMatrix(
                 m_Camera.nearClipPlane, m_Camera.farClipPlane);
+
+            //Set camera FOV instead of setting camera projection matrix so other visual effects such as Post-Processing stack won't break 
+            m_Camera.fieldOfView = Mathf.Atan(1 / prjMat[5]) * 2f * Mathf.Rad2Deg;
         }
 
         private void Disable()


### PR DESCRIPTION
I encountered issue with adding Unity Post-Processing effects stack to arcore sample project: cameras field of view was overriden when postprocessing effects was enabled. So I discovered culprit of this problem: ARCoreBackgroundRenderer was controlling FOV of the main camera using projection matrix instead of Unity Camera FOV parameter. So I managed to extract FOV value from arcore projection matrix and set it directly.