### PR TITLE
Fix: Culture invariant float to string conversion in AugmentedImageDatabase

### DIFF
--- a/Assets/GoogleARCore/SDK/Scripts/AugmentedImageDatabase.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/AugmentedImageDatabase.cs
@@ -29,6 +29,7 @@ namespace GoogleARCore
 
 #if UNITY_EDITOR
     using System.IO;
+    using System.Globalization;
     using UnityEditor;
 #endif
 
@@ -256,7 +257,7 @@ namespace GoogleARCore
                 sb.Append(m_Images[i].Name).Append('|').Append(imagePath);
                 if (m_Images[i].Width > 0)
                 {
-                    sb.Append('|').Append(m_Images[i].Width);
+                    sb.Append('|').Append(m_Images[i].Width.ToString(CultureInfo.InvariantCulture));
                 }
 
                 fileLines[i] = sb.ToString();


### PR DESCRIPTION
Hey,

I encountered an issue when specifying non-integer values as AugmentedImageDatabaseEntry's physical width inside the Unity Editor (build-and-run crashes). The bug happens when converting image's physical width from float to string in AugmentedImageDatabase.cs line 259, because the decimal separator is culture dependent and the AugmentedImageCLI-tool expects dot to be used.

